### PR TITLE
Dont replace walk mode

### DIFF
--- a/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
+++ b/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
@@ -121,13 +121,13 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 			}
 			String mode = paramset.getMode();
 			String overrideMode = null;
-			if (mode.equals(TransportMode.walk) || mode.equals(TransportMode.transit_walk)) {
+//			if (mode.equals(TransportMode.walk) || mode.equals(TransportMode.transit_walk)) {
 				// yyyyyy Das passt nicht zusammen mit meinen Annahmen.  "walk" kann durchaus ein "network walk" sein; das wuerde hier dann
 				// uebergebuegelt werden.  Ist diese Abfrage denn noetig?  kai, jun'19
 				// Habe gerade mal "walk" an den entscheidenden Stellen durch "bike" ersetzt; damit funktioniert es dann wie vorgesehen.  Das
 				// impliziert erstmal, dass "walk" hier problematisch ist.  Ob die Weglassung woanders Probleme macht, weiss ich nicht.  kai, jun'19
-				overrideMode = TransportMode.non_network_walk; 
-			}
+//				overrideMode = TransportMode.non_network_walk; 
+//			}
 			String linkIdAttribute = paramset.getLinkIdAttribute();
 			String personFilterAttribute = paramset.getPersonFilterAttribute();
 			String personFilterValue = paramset.getPersonFilterValue();

--- a/src/main/java/ch/sbb/matsim/routing/pt/raptor/RandomAccessEgressModeRaptorStopFinder.java
+++ b/src/main/java/ch/sbb/matsim/routing/pt/raptor/RandomAccessEgressModeRaptorStopFinder.java
@@ -111,13 +111,13 @@ public class RandomAccessEgressModeRaptorStopFinder implements RaptorStopFinder 
 		double radius = paramset.getInitialSearchRadius();
 		String mode = paramset.getMode();
 		String overrideMode = null;
-		if (mode.equals(TransportMode.walk) || mode.equals(TransportMode.transit_walk)) {
+//		if (mode.equals(TransportMode.walk) || mode.equals(TransportMode.transit_walk)) {
 			// yyyyyy Das passt nicht zusammen mit meinen Annahmen.  "walk" kann durchaus ein "network walk" sein; das wuerde hier dann
 			// uebergebuegelt werden.  Ist diese Abfrage denn noetig?  kai, jun'19
 			// Habe gerade mal "walk" an den entscheidenden Stellen durch "bike" ersetzt; damit funktioniert es dann wie vorgesehen.  Das
 			// impliziert erstmal, dass "walk" hier problematisch ist.  Ob die Weglassung woanders Probleme macht, weiss ich nicht.  kai, jun'19
-			overrideMode = TransportMode.non_network_walk; 
-		}
+//			overrideMode = TransportMode.non_network_walk; 
+//		}
 		String linkIdAttribute = paramset.getLinkIdAttribute();
 		String personFilterAttribute = paramset.getPersonFilterAttribute();
 		String personFilterValue = paramset.getPersonFilterValue();

--- a/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
+++ b/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
@@ -70,7 +70,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(300); // Includes no stops
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(0);
@@ -107,7 +107,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // Includes stop B
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(0);
@@ -154,7 +154,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(1100);
@@ -212,7 +212,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // Includes stop B (not "walkAccessible")
             walkAccess.setInitialSearchRadius(600);  // Includes stop B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(0);
@@ -258,7 +258,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // Includes stop B
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(0);
@@ -310,7 +310,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(1100); // Includes stops B and C
             walkAccess.setInitialSearchRadius(600); // Includes stop B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(0);
@@ -368,7 +368,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Includes stop B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(600); // Includes stop C and D
@@ -420,7 +420,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(300); // Includes no stops
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(0);
@@ -457,7 +457,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // Includes stop B
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(0);
@@ -504,7 +504,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(1100);
@@ -562,7 +562,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // Includes stop B (not "walkAccessible")
             walkAccess.setInitialSearchRadius(600);  // Includes stop B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(0);
@@ -608,7 +608,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // Includes stop B
             walkAccess.setInitialSearchRadius(300); // Includes no stops
             walkAccess.setSearchExtensionRadius(0);
@@ -660,7 +660,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(1100); // Includes stops B and C
             walkAccess.setInitialSearchRadius(600); // Includes stop B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(0);
@@ -718,7 +718,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Includes stop B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(600); // Includes stop C and D
@@ -784,7 +784,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(0);
@@ -832,7 +832,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(600);
@@ -880,7 +880,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // only includes B
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(500); // includes C
@@ -935,7 +935,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1100); // Should include stops C and B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(0);
@@ -990,7 +990,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(1100); // Should include stops C and D
@@ -1042,7 +1042,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(0);
@@ -1090,7 +1090,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(600);
@@ -1138,7 +1138,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(600); // only includes B
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(500); // includes C
@@ -1193,7 +1193,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1100); // Should include stops C and B (not "walkAccessible")
             walkAccess.setSearchExtensionRadius(0);
@@ -1248,7 +1248,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(600); // Should include stops B
             walkAccess.setSearchExtensionRadius(1100); // Should include stops C and D
@@ -1316,7 +1316,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1200); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(2000);
@@ -1366,7 +1366,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1200); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(0);
@@ -1425,7 +1425,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1600); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(500);
@@ -1483,7 +1483,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1600); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(500);
@@ -1539,7 +1539,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1200); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(2000);
@@ -1589,7 +1589,7 @@ public class RaptorStopFinderTest {
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1200); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(0);
@@ -1648,7 +1648,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1600); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(500);
@@ -1706,7 +1706,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1600); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(500);
@@ -1783,13 +1783,6 @@ public class RaptorStopFinderTest {
             zoomerAccess.setStopFilterValue("true");
             f0.srrConfig.addIntermodalAccessEgress(zoomerAccess);
 
-            SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
-            walkAccess.setRadius(0); // should not be limiting factor
-            walkAccess.setInitialSearchRadius(0); // Should include stops B and C and D
-            walkAccess.setSearchExtensionRadius(0); // includes D (if neccessary)
-            f0.srrConfig.addIntermodalAccessEgress(walkAccess);
-
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet nonNetworkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
             nonNetworkAccess.setMode(TransportMode.non_network_walk);
             nonNetworkAccess.setRadius(0); // should not be limiting factor
@@ -1860,7 +1853,7 @@ public class RaptorStopFinderTest {
             f0.srrConfig.addIntermodalAccessEgress(zoomerAccess);
 
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(0); // should not be limiting factor
             walkAccess.setInitialSearchRadius(0); // Should include stops B and C and D
             walkAccess.setSearchExtensionRadius(0); // includes D (if neccessary)
@@ -1926,7 +1919,7 @@ public class RaptorStopFinderTest {
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(10000000); // should not be limiting factor
             walkAccess.setInitialSearchRadius(1200); // Should include stops B and C
             walkAccess.setSearchExtensionRadius(2000);

--- a/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -53,25 +53,22 @@ public class SwissRailRaptorIntermodalTest {
     public void testIntermodalTrip() {
         IntermodalFixture f = new IntermodalFixture();
 
-        PlanCalcScoreConfigGroup.ModeParams accessWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        accessWalk.setMarginalUtilityOfTraveling(0.0);
-        f.config.planCalcScore().addModeParams(accessWalk);
+        PlanCalcScoreConfigGroup.ModeParams nonNetworkWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
+        nonNetworkWalk.setMarginalUtilityOfTraveling(0.0);
+        f.config.planCalcScore().addModeParams(nonNetworkWalk);
         PlanCalcScoreConfigGroup.ModeParams transitWalk = new PlanCalcScoreConfigGroup.ModeParams("transit_walk");
         transitWalk.setMarginalUtilityOfTraveling(0.0);
         f.config.planCalcScore().addModeParams(transitWalk);
-        PlanCalcScoreConfigGroup.ModeParams egressWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        egressWalk.setMarginalUtilityOfTraveling(0.0);
-        f.config.planCalcScore().addModeParams(egressWalk);
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
-        routingModules.put(TransportMode.walk,
-            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+        routingModules.put(TransportMode.non_network_walk,
+            new TeleportationRoutingModule(TransportMode.non_network_walk, f.scenario, 1.1, 1.3));
         routingModules.put(TransportMode.bike,
             new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
-        walkAccess.setMode(TransportMode.walk);
+        walkAccess.setMode(TransportMode.non_network_walk);
         walkAccess.setRadius(1000);
         walkAccess.setInitialSearchRadius(1000);
         f.srrConfig.addIntermodalAccessEgress(walkAccess);
@@ -124,22 +121,22 @@ public class SwissRailRaptorIntermodalTest {
     public void testIntermodalTrip_TripRouterIntegration() {
         IntermodalFixture f = new IntermodalFixture();
 
-        RoutingModule walkRoutingModule = new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3);
+        RoutingModule walkRoutingModule = new TeleportationRoutingModule(TransportMode.non_network_walk, f.scenario, 1.1, 1.3);
         RoutingModule bikeRoutingModule = new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4);
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
-        routingModules.put(TransportMode.walk, walkRoutingModule);
+        routingModules.put(TransportMode.non_network_walk, walkRoutingModule);
         routingModules.put(TransportMode.bike, bikeRoutingModule);
 
         TripRouter.Builder tripRouterBuilder = new TripRouter.Builder(f.config)
-        		.setRoutingModule(TransportMode.walk, walkRoutingModule)
+        		.setRoutingModule(TransportMode.non_network_walk, walkRoutingModule)
         		.setRoutingModule(TransportMode.bike, bikeRoutingModule);
         
         TripRouter tripRouter = tripRouterBuilder.build();
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
-        walkAccess.setMode(TransportMode.walk);
+        walkAccess.setMode(TransportMode.non_network_walk);
         walkAccess.setRadius(1000);
         walkAccess.setInitialSearchRadius(1000);
         f.srrConfig.addIntermodalAccessEgress(walkAccess);
@@ -152,15 +149,12 @@ public class SwissRailRaptorIntermodalTest {
         bikeAccess.setStopFilterValue("true");
         f.srrConfig.addIntermodalAccessEgress(bikeAccess);
 
-        PlanCalcScoreConfigGroup.ModeParams accessWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        accessWalk.setMarginalUtilityOfTraveling(0.0);
-        f.config.planCalcScore().addModeParams(accessWalk);
+        PlanCalcScoreConfigGroup.ModeParams nonNetworkWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
+        nonNetworkWalk.setMarginalUtilityOfTraveling(0.0);
+        f.config.planCalcScore().addModeParams(nonNetworkWalk);
         PlanCalcScoreConfigGroup.ModeParams transitWalk = new PlanCalcScoreConfigGroup.ModeParams("transit_walk");
         transitWalk.setMarginalUtilityOfTraveling(0.0);
         f.config.planCalcScore().addModeParams(transitWalk);
-        PlanCalcScoreConfigGroup.ModeParams egressWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        egressWalk.setMarginalUtilityOfTraveling(0.0);
-        f.config.planCalcScore().addModeParams(egressWalk);
 
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
@@ -212,25 +206,22 @@ public class SwissRailRaptorIntermodalTest {
     public void testIntermodalTrip_walkOnlyNoSubpop() {
         IntermodalFixture f = new IntermodalFixture();
 
-        PlanCalcScoreConfigGroup.ModeParams accessWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        accessWalk.setMarginalUtilityOfTraveling(-8.0);
-        f.config.planCalcScore().addModeParams(accessWalk);
+        PlanCalcScoreConfigGroup.ModeParams nonNetworkWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
+        nonNetworkWalk.setMarginalUtilityOfTraveling(-8.0);
+        f.config.planCalcScore().addModeParams(nonNetworkWalk);
         PlanCalcScoreConfigGroup.ModeParams transitWalk = new PlanCalcScoreConfigGroup.ModeParams("transit_walk");
         transitWalk.setMarginalUtilityOfTraveling(0.0);
         f.config.planCalcScore().addModeParams(transitWalk);
-        PlanCalcScoreConfigGroup.ModeParams egressWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        egressWalk.setMarginalUtilityOfTraveling(-8.0);
-        f.config.planCalcScore().addModeParams(egressWalk);
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
-        routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+        routingModules.put(TransportMode.non_network_walk,
+                new TeleportationRoutingModule(TransportMode.non_network_walk, f.scenario, 1.1, 1.3));
         routingModules.put(TransportMode.bike,
                 new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
-        walkAccess.setMode(TransportMode.walk);
+        walkAccess.setMode(TransportMode.non_network_walk);
         walkAccess.setRadius(1000);
         walkAccess.setInitialSearchRadius(1000);
         f.srrConfig.addIntermodalAccessEgress(walkAccess);
@@ -274,19 +265,16 @@ public class SwissRailRaptorIntermodalTest {
     public void testIntermodalTrip_withoutPt() {
         IntermodalFixture f = new IntermodalFixture();
 
-        PlanCalcScoreConfigGroup.ModeParams accessWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        accessWalk.setMarginalUtilityOfTraveling(0.0);
-        f.config.planCalcScore().addModeParams(accessWalk);
+        PlanCalcScoreConfigGroup.ModeParams nonNetworkWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
+        nonNetworkWalk.setMarginalUtilityOfTraveling(0.0);
+        f.config.planCalcScore().addModeParams(nonNetworkWalk);
         PlanCalcScoreConfigGroup.ModeParams transitWalk = new PlanCalcScoreConfigGroup.ModeParams("transit_walk");
         transitWalk.setMarginalUtilityOfTraveling(0.0);
         f.config.planCalcScore().addModeParams(transitWalk);
-        PlanCalcScoreConfigGroup.ModeParams egressWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        egressWalk.setMarginalUtilityOfTraveling(0.0);
-        f.config.planCalcScore().addModeParams(egressWalk);
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
-        routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+        routingModules.put(TransportMode.non_network_walk,
+                new TeleportationRoutingModule(TransportMode.non_network_walk, f.scenario, 1.1, 1.3));
         routingModules.put(TransportMode.bike,
                 new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
 
@@ -324,29 +312,25 @@ public class SwissRailRaptorIntermodalTest {
         IntermodalFixture f = new IntermodalFixture();
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
-        routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+        routingModules.put(TransportMode.non_network_walk,
+                new TeleportationRoutingModule(TransportMode.non_network_walk, f.scenario, 1.1, 1.3));
         routingModules.put(TransportMode.bike,
                 new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
 
-        // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
+        // we need to set special values for walk and bike as the defaults are the same for walk(=non_network_walk), bike and waiting
         // which would result in all options having the same cost in the end.
-        f.config.planCalcScore().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(-7);
         f.config.planCalcScore().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
 
-        PlanCalcScoreConfigGroup.ModeParams accessWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        accessWalk.setMarginalUtilityOfTraveling(0);
-        f.config.planCalcScore().addModeParams(accessWalk);
+        PlanCalcScoreConfigGroup.ModeParams nonNetworkWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
+        nonNetworkWalk.setMarginalUtilityOfTraveling(-7);
+        f.config.planCalcScore().addModeParams(nonNetworkWalk);
         PlanCalcScoreConfigGroup.ModeParams transitWalk = new PlanCalcScoreConfigGroup.ModeParams("transit_walk");
         transitWalk.setMarginalUtilityOfTraveling(0);
         f.config.planCalcScore().addModeParams(transitWalk);
-        PlanCalcScoreConfigGroup.ModeParams egressWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        egressWalk.setMarginalUtilityOfTraveling(0);
-        f.config.planCalcScore().addModeParams(egressWalk);
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
-        walkAccess.setMode(TransportMode.walk);
+        walkAccess.setMode(TransportMode.non_network_walk);
         walkAccess.setRadius(100); // force to nearest stops
         walkAccess.setInitialSearchRadius(100);
         f.srrConfig.addIntermodalAccessEgress(walkAccess);
@@ -426,29 +410,25 @@ public class SwissRailRaptorIntermodalTest {
         IntermodalFixture f = new IntermodalFixture();
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
-        routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+        routingModules.put(TransportMode.non_network_walk,
+                new TeleportationRoutingModule(TransportMode.non_network_walk, f.scenario, 1.1, 1.3));
         routingModules.put(TransportMode.bike,
                 new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
 
-        // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
+        // we need to set special values for walk and bike as the defaults are the same for walk(=non_network_walk), bike and waiting
         // which would result in all options having the same cost in the end.
-        f.config.planCalcScore().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(-7);
         f.config.planCalcScore().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
 
-        PlanCalcScoreConfigGroup.ModeParams accessWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        accessWalk.setMarginalUtilityOfTraveling(0);
-        f.config.planCalcScore().addModeParams(accessWalk);
+        PlanCalcScoreConfigGroup.ModeParams nonNetworkWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
+        nonNetworkWalk.setMarginalUtilityOfTraveling(-7);
+        f.config.planCalcScore().addModeParams(nonNetworkWalk);
         PlanCalcScoreConfigGroup.ModeParams transitWalk = new PlanCalcScoreConfigGroup.ModeParams("transit_walk");
         transitWalk.setMarginalUtilityOfTraveling(0);
         f.config.planCalcScore().addModeParams(transitWalk);
-        PlanCalcScoreConfigGroup.ModeParams egressWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        egressWalk.setMarginalUtilityOfTraveling(0);
-        f.config.planCalcScore().addModeParams(egressWalk);
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
-        walkAccess.setMode(TransportMode.walk);
+        walkAccess.setMode(TransportMode.non_network_walk);
         walkAccess.setRadius(100); // force to nearest stops
         f.srrConfig.addIntermodalAccessEgress(walkAccess);
 
@@ -532,29 +512,25 @@ public class SwissRailRaptorIntermodalTest {
         IntermodalFixture f = new IntermodalFixture();
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
-        routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+        routingModules.put(TransportMode.non_network_walk,
+                new TeleportationRoutingModule(TransportMode.non_network_walk, f.scenario, 1.1, 1.3));
         routingModules.put(TransportMode.bike,
                 new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
 
-        // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
+        // we need to set special values for walk and bike as the defaults are the same for walk(=non_network_walk), bike and waiting
         // which would result in all options having the same cost in the end.
-        f.config.planCalcScore().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(-7);
         f.config.planCalcScore().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
 
-        PlanCalcScoreConfigGroup.ModeParams accessWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        accessWalk.setMarginalUtilityOfTraveling(0);
-        f.config.planCalcScore().addModeParams(accessWalk);
+        PlanCalcScoreConfigGroup.ModeParams nonNetworkWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
+        nonNetworkWalk.setMarginalUtilityOfTraveling(-7);
+        f.config.planCalcScore().addModeParams(nonNetworkWalk);
         PlanCalcScoreConfigGroup.ModeParams transitWalk = new PlanCalcScoreConfigGroup.ModeParams("transit_walk");
         transitWalk.setMarginalUtilityOfTraveling(0);
         f.config.planCalcScore().addModeParams(transitWalk);
-        PlanCalcScoreConfigGroup.ModeParams egressWalk = new PlanCalcScoreConfigGroup.ModeParams("non_network_walk");
-        egressWalk.setMarginalUtilityOfTraveling(0);
-        f.config.planCalcScore().addModeParams(egressWalk);
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
-        walkAccess.setMode(TransportMode.walk);
+        walkAccess.setMode(TransportMode.non_network_walk);
         walkAccess.setDirections("ACCESS,EGRESS");
         walkAccess.setRadius(100); // force to nearest stops
         walkAccess.setInitialSearchRadius(100);
@@ -971,16 +947,15 @@ public class SwissRailRaptorIntermodalTest {
             // ---
 
             this.routingModules = new HashMap<>();
-            this.routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, this.scenario, 1.1, 1.3));
+            this.routingModules.put(TransportMode.non_network_walk,
+                    new TeleportationRoutingModule(TransportMode.non_network_walk, this.scenario, 1.1, 1.3));
             this.routingModules.put(TransportMode.non_network_walk,
                     new TeleportationRoutingModule(TransportMode.non_network_walk, this.scenario, 1.1, 1.3));
             this.routingModules.put(TransportMode.bike,
                     new TeleportationRoutingModule(TransportMode.bike, this.scenario, 10, 1.4)); // make bike very fast
 
-            // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
+            // we need to set special values for walk and bike as the defaults are the same for walk (=non_network_walk), bike and waiting
             // which would result in all options having the same cost in the end.
-            this.config.planCalcScore().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(-7);
             this.config.planCalcScore().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
 
             this.config.transitRouter().setMaxBeelineWalkConnectionDistance(150);
@@ -1009,7 +984,7 @@ public class SwissRailRaptorIntermodalTest {
 
             this.srrConfig.setUseIntermodalAccessEgress(true);
             IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
-            walkAccess.setMode(TransportMode.walk);
+            walkAccess.setMode(TransportMode.non_network_walk);
             walkAccess.setRadius(500);
             walkAccess.setInitialSearchRadius(500);
             this.srrConfig.addIntermodalAccessEgress(walkAccess);


### PR DESCRIPTION
currently the intermodal stop finders DefaultRaptorStopFinder and RandomAccessEgressModeRaptorStopFinder replace modes "walk" and "transit_walk" by "non_network_walk". That is not nice and somewhat unexpected. Rather not replace the mode and directly use non_network_walk as access/egress mode.